### PR TITLE
Fix/add http security headers 1

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -111,7 +111,7 @@ def add_security_headers(response):
         "font-src 'self';"
 
     )
-
+    response.headers.remove('Server')
     return response
 # Use threading mode for broad compatibility
 # Configure with longer timeouts and ping/pong to keep connection alive during long scans

--- a/src/app.py
+++ b/src/app.py
@@ -80,6 +80,39 @@ app.config['SECRET_KEY'] = (
     or os.environ.get('SECRET_KEY')
     or secrets.token_hex(32)
 )
+@app.after_request
+
+def add_security_headers(response):
+
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+
+    response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+
+    response.headers['X-XSS-Protection'] = '1; mode=block'
+
+    response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
+
+    response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+
+    response.headers['Permissions-Policy'] = 'geolocation=(), microphone=(), camera=()'
+
+    response.headers['Content-Security-Policy'] = (
+
+        "default-src 'self'; "
+
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.socket.io; "
+
+        "style-src 'self' 'unsafe-inline'; "
+
+        "img-src 'self' data:; "
+
+        "connect-src 'self' wss: ws:; "
+
+        "font-src 'self';"
+
+    )
+
+    return response
 # Use threading mode for broad compatibility
 # Configure with longer timeouts and ping/pong to keep connection alive during long scans
 socketio = SocketIO(

--- a/src/app.py
+++ b/src/app.py
@@ -81,35 +81,20 @@ app.config['SECRET_KEY'] = (
     or secrets.token_hex(32)
 )
 @app.after_request
-
 def add_security_headers(response):
-
     response.headers['X-Content-Type-Options'] = 'nosniff'
-
     response.headers['X-Frame-Options'] = 'SAMEORIGIN'
-
     response.headers['X-XSS-Protection'] = '1; mode=block'
-
     response.headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains'
-
     response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
-
     response.headers['Permissions-Policy'] = 'geolocation=(), microphone=(), camera=()'
-
     response.headers['Content-Security-Policy'] = (
-
         "default-src 'self'; "
-
         "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.socket.io; "
-
         "style-src 'self' 'unsafe-inline'; "
-
         "img-src 'self' data:; "
-
         "connect-src 'self' wss: ws:; "
-
         "font-src 'self';"
-
     )
     response.headers.remove('Server')
     return response


### PR DESCRIPTION
I have made changes to **src/app.py** to add HTTP security headers to all Flask responses via an **after_request** handler.

The app was not sending any security headers, which left it open to common attacks like **clickjacking, XSS, MIME sniffing, and HTTP** downgrade attacks.

**Headers added:**
Content-Security-Policy — prevents XSS attacks
Strict-Transport-Security — enforces HTTPS
X-Frame-Options — prevents clickjacking
X-Content-Type-Options — stops MIME sniffing
X-XSS-Protection — additional XSS protection
Referrer-Policy — prevents URL leaking
Permissions-Policy — blocks camera/mic/location access

Tested locally with **curl -I http://127.0.0.1:5000** and confirmed all 7 headers are present in the response.

**Note:** Server header suppression is included but Werkzeug re-adds it in dev mode. Full suppression should be handled at the reverse proxy level in production.

<img width="587" height="289" alt="image" src="https://github.com/user-attachments/assets/c6a09a1f-8d63-4ef6-991a-abdcebb97985" />

Closes #69 